### PR TITLE
v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Renamed `end` to `start` in a few forgotten places (url util functions)
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,22 @@
 
 ### Fixed
 
+### Deprecated
+
+### Removed
+
+
+
+## [0.5.1] - 2020-08-29
+
+### Added
+
+### Changed
+
+### Fixed
+
 - Renamed `end` to `start` in a few forgotten places (url util functions)
+- Strip trailing slash in base urls instead of stupidy failing
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
 # Humio API (unofficial lib)
 
+> This project requires `Python>=3.6.1`
+
 This is an unofficial library for interacting with [Humio](https://www.humio.com/)'s API. If you're looking for the official Python Humio library it can be found [here: humiolib](https://github.com/humio/python-humio). This library mostly exists because the official library was incredibly basic back in 2019 when I needed this.
+
+## Installation
+
+    pip install humiocli
 
 ## Main features
 
-* Asyncronous and syncronous streaming queries supported by `httpx`
+* Asyncronous and syncronous streaming queries supported by `httpx`.
 * Queryjobs which can be polled once, or until completed.
-* Chainable relative time modifiers (similar to Splunk e.g. `-1d@h-30m`)
-* List repository details (*NOTE*: normal Humio users cannot see repos without read permission)
-* Easy env-variable based configuration
+* Chainable relative time modifiers (similar to Splunk e.g. `-1d@h-30m`).
+* List repository details (*NOTE*: normal Humio users cannot see repos without read permission).
+* Easy env-variable based configuration.
 * Ingest data to Humio, although you probably want to use Filebeat for anything other than one-off things to your sandbox.
-* (*Work in progress*) Create and update parsers.
+* CLI companion tool available at [humiocli](https://github.com/gwtwod/humiocli).
+* Create and update parsers.
 * (*Work in progress*) An updateable timeseries, which can follow a moving timewindow using relative modifiers, optionally querying only the changed timewindow since previous update.
 
 ## Usage
@@ -115,7 +122,7 @@ import pandas as pd
 sns.set(color_codes=True)
 sns.set_style('darkgrid')
 
-results = api.streaming_search(query='log_type=stats | timechart(series=metric)', repos=['frontend'], start=start, end=end)
+results = api.streaming_search(query='log_type=stats | timechart(series=metric)', repos=['frontend'], start=start, stop=stop)
 df = pd.DataFrame(results)
 df['_count'] = df['_count'].astype(float)
 

--- a/humioapi/api.py
+++ b/humioapi/api.py
@@ -18,7 +18,7 @@ logger = structlog.getLogger(__name__)
 
 class HumioAPI:
     def __init__(self, token=None, ingest_token=None, base_url="https://cloud.humio.com", **kwargs):
-        self.base_url = base_url
+        self.base_url = base_url.rstrip("/")
         self.api_version = "v1"
         self.token = token
         self.ingest_token = ingest_token

--- a/humioapi/api.py
+++ b/humioapi/api.py
@@ -39,16 +39,7 @@ class HumioAPI:
             headers["authorization"] = "Bearer " + headers["authorization"]
         return headers
 
-    def create_queryjob(
-        self,
-        query,
-        repo,
-        start="-2d@d",
-        stop="now",
-        live=False,
-        tz_offset=0,
-        literal_time=False,
-    ):
+    def create_queryjob(self, query, repo, start="-2d@d", stop="now", live=False, tz_offset=0, literal_time=False):
         """
         Creates a remote queryjob and returns its job ID.
 
@@ -222,7 +213,7 @@ class HumioAPI:
 
         with httpx.Client(headers=headers, timeout=httpx.Timeout(None)) as client:
             for url in urls:
-                with client.stream("POST", url=url, json=payload,) as r:
+                with client.stream("POST", url=url, json=payload) as r:
                     # Humio doesn't set the charset, and httpx fails to detect it properly
                     r.headers.update({"content-type": "application/x-ndjson; charset=UTF-8"})
                     r.raise_for_status()
@@ -230,7 +221,7 @@ class HumioAPI:
                     try:
                         for event in r.iter_lines():
                             yield json.loads(event)
-                    except RemoteProtocolError:
+                    except httpx.RemoteProtocolError:
                         # Humio doesn't necessarily have any more data to send when the query has completed
                         r.close()
 
@@ -293,7 +284,7 @@ class HumioAPI:
 
         async def stream(async_client, url, payload):
             async with concurrent_limiter:
-                async with async_client.stream("POST", url=url, json=payload,) as ar:
+                async with async_client.stream("POST", url=url, json=payload) as ar:
                     # Humio doesn't set the charset, and httpx fails to detect it properly
                     ar.headers.update({"content-type": "application/x-ndjson; charset=UTF-8"})
                     ar.raise_for_status()
@@ -356,9 +347,7 @@ class HumioAPI:
         pending = []
         for event in events:
             if len("".join(pending)) >= soft_limit:
-                logger.warn(
-                    "An event exceeds the soft limit", length=len("".join(pending)), soft_limit=soft_limit,
-                )
+                logger.warn("An event exceeds the soft limit", length=len("".join(pending)), soft_limit=soft_limit)
                 _send(headers, url, pending, fields, soft_limit, dry)
                 del pending[:]
             elif len("".join(pending)) + len(event) >= soft_limit:
@@ -421,9 +410,7 @@ class HumioAPI:
                     "favourite": repo["isStarred"],
                 }
             except (KeyError, AttributeError) as exc:
-                logger.exception(
-                    "Couldn't map repository/view object", repo=repo.get("name"), error_message=exc,
-                )
+                logger.exception("Couldn't map repository/view object", repo=repo.get("name"), error_message=exc)
         return repositories
 
     def create_update_parser(self, repos, parser, source):
@@ -483,9 +470,7 @@ class HumioAPI:
 
             existing_repo = req.json().get("data")
             if not existing_repo:
-                logger.error(
-                    "Did not find a repo with the given name, verify its existence and your access", repo=repo,
-                )
+                logger.error("Did not find a repo with the given name, verify its existence and your access", repo=repo)
                 result["failed"].append(repo)
                 continue
 
@@ -497,7 +482,7 @@ class HumioAPI:
                 response = req.json()
                 if response.get("errors"):
                     logger.error(
-                        "Failed to create new parser", repo=repo, parser=parser, json_payload=(json.dumps(response)),
+                        "Failed to create new parser", repo=repo, parser=parser, json_payload=(json.dumps(response))
                     )
                     result["failed"].append(repo)
                     continue
@@ -512,10 +497,7 @@ class HumioAPI:
                     response = req.json()
                     if response.get("errors"):
                         logger.error(
-                            "Failed to create new parser",
-                            repo=repo,
-                            parser=parser,
-                            json_payload=(json.dumps(response)),
+                            "Failed to create new parser", repo=repo, parser=parser, json_payload=(json.dumps(response))
                         )
                         result["failed"].append(repo)
                         continue

--- a/humioapi/queryjob.py
+++ b/humioapi/queryjob.py
@@ -38,7 +38,7 @@ class QueryJob:
     """
 
     def __init__(
-        self, token, base_url, query, repo, start="-2d@d", stop="now", live=False, literal_time=False, job_id=None,
+        self, token, base_url, query, repo, start="-2d@d", stop="now", live=False, literal_time=False, job_id=None
     ):
         self.client = HumioAPI(token=token, base_url=base_url)
         self.query = query

--- a/humioapi/timeseries.py
+++ b/humioapi/timeseries.py
@@ -100,7 +100,7 @@ class WindowedTimeseries:
             self.load_df()
 
         logger.debug(
-            "Initialized search object definition", start=self.start, stop=self.stop, event_count=len(self.data),
+            "Initialized search object definition", start=self.start, stop=self.stop, event_count=len(self.data)
         )
 
     def copyable_attributes(self, ignore=None):
@@ -145,7 +145,7 @@ class WindowedTimeseries:
 
             self.data = pd.read_pickle(self.trusted_pickle + ".pkl")
             logger.debug(
-                "Loaded pickled data from file", event_count=len(self.data), pickle=self.trusted_pickle + ".pkl",
+                "Loaded pickled data from file", event_count=len(self.data), pickle=self.trusted_pickle + ".pkl"
             )
         except FileNotFoundError:
             pass
@@ -155,9 +155,7 @@ class WindowedTimeseries:
         with open(self.trusted_pickle + ".meta", "w") as metafile:
             json.dump(self.copyable_attributes(), metafile)
         self.data.to_pickle(self.trusted_pickle + ".pkl")
-        logger.debug(
-            "Saved pickled data to file", event_count=len(self.data), pickle=self.trusted_pickle + ".pkl",
-        )
+        logger.debug("Saved pickled data to file", event_count=len(self.data), pickle=self.trusted_pickle + ".pkl")
 
     def current_refresh_window(self):
         """Returns the smallest possible search window required to update missing data
@@ -225,7 +223,7 @@ class WindowedTimeseries:
                     if new_data:
                         logger.info("Search returned new data", events=len(new_data))
                         data = humio_to_timeseries(
-                            new_data, timefield=self.timefield, datafields=self.datafields, groupby=self.groupby,
+                            new_data, timefield=self.timefield, datafields=self.datafields, groupby=self.groupby
                         )
                         self.data = data.combine_first(self.data)
 

--- a/humioapi/utils.py
+++ b/humioapi/utils.py
@@ -190,11 +190,11 @@ def parse_humio_url(url):
 
     Returns
     -------
-    tuple
-        query : str
-        repo : str
-        start : DateTime
-        end : DateTime
+    Tuple
+        (query : str,
+        repo : str,
+        start : DateTime,
+        stop : DateTime)
     """
 
     parsed = urllib.parse.urlparse(url)
@@ -207,22 +207,23 @@ def parse_humio_url(url):
     if start.isdigit():
         start = parse_ts(start)
     else:
-        # Humio doesnt use signed relative time modifiers
+        # Humio doesnt use signed relative time modifiers. Unlike Splunk's
+        # relative time modifiers, Humio's are are always in the past
         start = parse_ts(f"-{start}")
 
-    end = querystring.get("end", ["now"])[0]
-    end = parse_ts(end)
+    stop = querystring.get("end", ["now"])[0]
+    stop = parse_ts(stop)
 
-    return (query, repo, start, end)
+    return (query, repo, start, stop)
 
 
-def create_humio_url(base_url, repo, query, start, end, scheme="https"):
+def create_humio_url(base_url, repo, query, start, stop, scheme="https"):
     """Returns a Humio search URL built from the provided components"""
 
-    start = int(start.timestamp() * 1000)
-    end = int(end.timestamp() * 1000)
+    start = int(parse_ts(start).timestamp() * 1000)
+    stop = int(parse_ts(stop).timestamp() * 1000)
 
-    query = {"query": query, "start": start, "end": end}
+    query = {"query": query, "start": start, "end": stop}
 
     url = urllib.parse.ParseResult(
         scheme=scheme,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "humioapi"
-version = "0.5.0"
+version = "0.5.1"
 description = "A Python library for easy interaction with the Humio API"
 authors = ["Jostein Haukeli"]
 repository = "https://github.com/gwtwod/humioapi"


### PR DESCRIPTION
- Renamed `end` to `start` in a few forgotten places (url util functions)
- Strip trailing slash in base urls instead of stupidy failing