### PR TITLE
Switch to urllib3 as networking backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-
 ## [Unreleased]
 
 ### Added
@@ -13,6 +12,15 @@
 
 ### Removed
 
+
+## [0.7.0] - 2021-01-31
+
+### Changed
+
+- Changed all syncronous requests through `httpx` to use urllib3 as networking backend rather than `httpcore` as a 
+temporary solution, since the humio-search-all and graphql endpoints started giving random HTTP 502s since Humio 1.18.
+Will probably revert in the future when I can figure out whats up.
+- Changed the `humioapi.loadenv()` helper to accept iterables of envs and prefixes as well as the old strings.
 
 ## [0.6.2] - 2020-12-17
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > This project requires `Python>=3.6.1`
 
-This is an unofficial library for interacting with [Humio](https://www.humio.com/)'s API. If you're looking for the official Python Humio library it can be found [here: humiolib](https://github.com/humio/python-humio). This library mostly exists because the official library was very basic back in 2019 when I first needed this.
+This is an unofficial library for interacting with [Humio](https://www.humio.com/)'s API. If you're looking for the official Python Humio library it can be found [here: humiolib](https://github.com/humio/python-humio). This library mostly exists because the official library was very basic back in 2019 when I first needed this. You probably want the official lib instead.
 
 ## Installation
 
@@ -22,7 +22,9 @@ This is an unofficial library for interacting with [Humio](https://www.humio.com
 
 ## Usage
 
-For convenience your Humio URL and token should be set in the environment variables `HUMIO_BASE_URL` and `HUMIO_TOKEN`. These can be set in `~/.config/humio/.env` and loaded by `humioapi.loadenv()`.
+For convenience your Humio URL and tokens should be set in the environment variables `HUMIO_BASE_URL` and `HUMIO_TOKEN`.
+These can be set in `~/.config/humio/.env` and loaded through `humioapi.loadenv()`, which loads all `HUMIO_`-prefixed
+variables found in the env-file.
 
 ## Query repositories
 
@@ -147,3 +149,5 @@ sns.lineplot(data=df)
 ## SSL and proxies
 
 All HTTP traffic is done through `httpx`, which allows customizing SSL and proxy behaviour through environment variables. See [httpx docs](https://www.python-httpx.org/environment_variables/) for details.
+
+>This is unavailable since 0.7.* due to switching to urllib3 as networking backend to solve a problem with random HTTP 502s from the graphql/humio-search-all endpoints.

--- a/humioapi/loadenv.py
+++ b/humioapi/loadenv.py
@@ -7,12 +7,60 @@ from dotenv import load_dotenv
 def loadenv(env=None, prefix="HUMIO_"):
     """
     Load all environment variables from the specified `env` file into `os.environ`
-    and return a dict of the variables matching the provided `prefix`. The key names will be
-    lower case with the HUMIO_ prefix stripped for ease of use as kwargs.
+    and return a dict of the variables matching the provided `prefix`.
+
+    The key names will be lower case with the prefix stripped for ease of use as kwargs.
+
+    The env file can have comments, and allows variables prefixed with `soruce`, which
+    will be ignored but allow easily sourcing the file in your shell.
+
+    Bare variables ($HOME) are not expanded, but ${HOME} will be expanded.
+
+    Parameters
+    ----------
+
+    env: string or list of strings
+        Path to env file(s) to load. Default `~/.config/humio/.env`.
+    prefix: string or list of strings
+        Prefix of env variables to load from the env files. Default `HUMIO_`.
+
+    Returns:
+        A dict with all relevant env variables loaded.
     """
+
+    if prefix is None or isinstance(prefix, str):
+        prefix = [prefix]
+
+    if env is None or isinstance(env, str):
+        env = [env]
+
+    config = {}
+
+    # source all env variables
+    for e in env:
+        for p in prefix:
+            load(env=e, prefix=p)
+
+    # find all relevant loaded env variables
+    for key in os.environ.keys():
+        for p in prefix:
+            if key.startswith(p):
+                normalized_key = removeprefix(key, p).lower()
+                config[normalized_key] = os.getenv(key)
+
+    return config
+
+
+def load(env=None, prefix=None):
+    """Loads all variables from an env file"""
 
     if env is None:
         env = Path.home() / ".config/humio/.env"
     load_dotenv(dotenv_path=env)
 
-    return {key[6:].lower(): os.getenv(key) for key in os.environ.keys() if key.startswith(prefix)}
+
+def removeprefix(s, prefix):
+    if s.startswith(prefix):
+        return s[len(prefix):]
+    return s
+

--- a/humioapi/urllib3_transport.py
+++ b/humioapi/urllib3_transport.py
@@ -1,0 +1,156 @@
+"""
+Original source: https://gist.github.com/florimondmanca/d56764d78d748eb9f73165da388e546e
+
+An HTTPCore transport that uses urllib3 as the HTTP networking backend. (This was initially shipped with HTTPX.)
+
+When used with HTTPX, this transport makes it easier to transition from Requests to HTTPX by keeping the same underlying HTTP networking layer.
+
+Compatible with: HTTPX 0.15.x, 0.16.x (i.e. HTTPCore 0.11.x and HTTPCore 0.12.x).
+
+Note: not all urllib3 pool manager options are supported here — feel free to adapt this gist to your specific needs.
+"""
+
+#MIT License
+#
+#Copyright (c) 2020 Florimond Manca
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+#The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import socket
+import ssl
+from typing import Dict, Iterator, List, Optional, Tuple
+
+import httpcore
+import urllib3
+
+
+class URLLib3ByteStream(httpcore.SyncByteStream):
+    def __init__(self, response: urllib3.HTTPResponse) -> None:
+        self._response = response
+
+    def __iter__(self) -> Iterator[bytes]:
+        try:
+            for chunk in self._response.stream(4096, decode_content=False):
+                yield chunk
+        except socket.error as exc:
+            raise httpcore.NetworkError(exc)
+
+    def close(self) -> None:
+        self._response.release_conn()
+
+
+class URLLib3Transport(httpcore.SyncHTTPTransport):
+    def __init__(
+        self,
+        *,
+        ssl_context: ssl.SSLContext = None,
+        pool_connections: int = 10,
+        pool_maxsize: int = 10,
+        pool_block: bool = False,
+    ) -> None:
+        self._pool = urllib3.PoolManager(
+            ssl_context=ssl_context,
+            num_pools=pool_connections,
+            maxsize=pool_maxsize,
+            block=pool_block,
+        )
+
+    def request(
+        self,
+        method: bytes,
+        url: Tuple[bytes, bytes, Optional[int], bytes],
+        headers: List[Tuple[bytes, bytes]] = None,
+        stream: httpcore.SyncByteStream = None,
+        ext: dict = None,
+    ) -> Tuple[int, List[Tuple[bytes, bytes]], httpcore.SyncByteStream, dict]:
+        headers = [] if headers is None else headers
+        stream = httpcore.PlainByteStream(b"") if stream is None else stream
+        ext = {} if ext is None else ext
+        timeout: Dict[str, float] = ext["timeout"]
+
+        urllib3_timeout = urllib3.util.Timeout(
+            connect=timeout.get("connect"), read=timeout.get("read")
+        )
+
+        chunked = False
+        content_length = 0
+        for header_key, header_value in headers:
+            header_key = header_key.lower()
+            if header_key == b"transfer-encoding":
+                chunked = header_value == b"chunked"
+            if header_key == b"content-length":
+                content_length = int(header_value.decode("ascii"))
+        body = stream if chunked or content_length else None
+
+        scheme, host, port, path = url
+        default_port = {b"http": 80, "https": 443}.get(scheme)
+        if port is None or port == default_port:
+            url_str = "%s://%s%s" % (
+                scheme.decode("ascii"),
+                host.decode("ascii"),
+                path.decode("ascii"),
+            )
+        else:
+            url_str = "%s://%s:%d%s" % (
+                scheme.decode("ascii"),
+                host.decode("ascii"),
+                port,
+                path.decode("ascii"),
+            )
+
+        try:
+            response = self._pool.urlopen(
+                method=method.decode(),
+                url=url_str,
+                headers={
+                    key.decode("ascii"): value.decode("ascii") for key, value in headers
+                },
+                body=body,
+                redirect=False,
+                assert_same_host=False,
+                retries=0,
+                preload_content=False,
+                chunked=chunked,
+                timeout=urllib3_timeout,
+                pool_timeout=timeout.get("pool"),
+            )
+        except (urllib3.exceptions.SSLError, socket.error) as exc:
+            raise httpcore.NetworkError(exc)
+
+        status_code = response.status
+        reason_phrase = response.reason
+        headers = list(response.headers.items())
+        stream = URLLib3ByteStream(response)
+        ext = {"reason": reason_phrase, "http_version": "HTTP/1.1"}
+
+        return (status_code, headers, stream, ext)
+
+    def close(self) -> None:
+        self._pool.clear()
+
+
+class URLLib3ProxyTransport(URLLib3Transport):
+    def __init__(
+        self,
+        *,
+        proxy_url: str,
+        proxy_headers: dict = None,
+        ssl_context: ssl.SSLContext = None,
+        pool_connections: int = 10,
+        pool_maxsize: int = 10,
+        pool_block: bool = False,
+    ) -> None:
+        self._pool = urllib3.ProxyManager(
+            proxy_url=proxy_url,
+            proxy_headers=proxy_headers,
+            ssl_context=ssl_context,
+            num_pools=pool_connections,
+            maxsize=pool_maxsize,
+            block=pool_block,
+        )
+

--- a/poetry.lock
+++ b/poetry.lock
@@ -700,6 +700,19 @@ version = "2.1"
 pytz = "*"
 
 [[package]]
+category = "main"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "1.26.3"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+
+[[package]]
 category = "dev"
 description = "Virtual Python Environment builder"
 name = "virtualenv"
@@ -747,7 +760,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "802f26a06f8fa80c9cbc0ad0fd8a6d3f55bed00ada889779cd761976ca5aa0ee"
+content-hash = "018bbb4798f9519b324c6a7fa40d619229b3425b59b3349a6bec5c7281e725fc"
 lock-version = "1.0"
 python-versions = "^3.6.1"
 
@@ -1139,6 +1152,10 @@ typing-extensions = [
 tzlocal = [
     {file = "tzlocal-2.1-py2.py3-none-any.whl", hash = "sha256:e2cb6c6b5b604af38597403e9852872d7f534962ae2954c7f35efcb1ccacf4a4"},
     {file = "tzlocal-2.1.tar.gz", hash = "sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.3-py2.py3-none-any.whl", hash = "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80"},
+    {file = "urllib3-1.26.3.tar.gz", hash = "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"},
 ]
 virtualenv = [
     {file = "virtualenv-20.0.31-py2.py3-none-any.whl", hash = "sha256:e0305af10299a7fb0d69393d8f04cb2965dda9351140d11ac8db4e5e3970451b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "humioapi"
-version = "0.6.2"
+version = "0.7.0"
 description = "An unofficial Python library for easy interaction with the Humio API"
 authors = ["Jostein Haukeli"]
 repository = "https://github.com/gwtwod/humioapi"
@@ -23,6 +23,7 @@ httpx = "^0.16.1"
 colorama = "^0.4.4"
 aiostream = "^0.4.1"
 pandas = {version = "^1.1.5", optional = true}
+urllib3 = "^1.26.3"
 
 [tool.poetry.dev-dependencies]
 black = {version = "*", allow-prereleases = true}


### PR DESCRIPTION
Temporary measure to solve a weird HTTP 502-issue with some Humio endpoints (humio-search-all, graphql) since Humio 1.18 which (almost?) only seems to happen with httpcore